### PR TITLE
Fix ‘incompatible’ facebook profile. Used ‘dist’ element intead of te…

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -118,7 +118,7 @@ var helper = require("./content_helpers.js"),
 window.onload = function() {
     console.log("\n\n\n\n\nKabooom. Content script loaded.");
     looked.getMinLookedDuration();
-    window.global.profileInfo = $("#pagelet_bluebar a[data-testid='blue_bar_profile_link']");
+    window.global.profileInfo = $("#pagelet_bluebar a[title='Profile']");
     if (window.global.profileInfo.length > 0) {
         // this is the beginning, bg only starts tracking
         // if profle img / logged in


### PR DESCRIPTION
data_selfie didn't work for me because the profile link was not found. The reason for this is that the DOM element uses some kind of test data from FB that can be changed by FB devs. at an time. 

I suggest using 'title' instead as I think it is a bit more reliable and not something the FB will be eager to change soon.